### PR TITLE
Prevent double slash in Export path and Export ready phase fix

### DIFF
--- a/src/main/java/se/simonsoft/cms/item/export/CmsExportJob.java
+++ b/src/main/java/se/simonsoft/cms/item/export/CmsExportJob.java
@@ -45,11 +45,18 @@ public class CmsExportJob extends CmsExportJobBase {
         }
 
         logger.info("Preparing: {} CmsExportItems for export.", getExportItems().size());
-
-        isPrepared = true;
+        
+        if (getExportItems().isEmpty()) {
+            throw new IllegalArgumentException("There's no items in the export job to prepare");
+        }
+        boolean itemsPrepared = false;
         for (CmsExportItem item : getExportItems()) {
             item.prepare();
+            if (!item.isReady()) {
+            	itemsPrepared = false;
+            }
         }
+        isPrepared = itemsPrepared;
     }
 
     /**
@@ -57,14 +64,15 @@ public class CmsExportJob extends CmsExportJobBase {
      * @return Boolean set to true if al items is ready.
      */
     public Boolean isReady() {
-
-        if (getExportItems().isEmpty()) {
-            throw new IllegalArgumentException("There's no items in the export job to prepare");
-        }
+    	
+    	if (getExportItems().isEmpty()) {
+    		throw new IllegalArgumentException("There's no items in the export job.");
+    	}
 
         if (isPrepared) {
             return isPrepared;
         }
+        
 
         //TODO: We should remember if an ExportItem is ready, so we don't have to check again do it again.
         for (CmsExportItem item: getExportItems()) {

--- a/src/main/java/se/simonsoft/cms/item/export/CmsExportJobBase.java
+++ b/src/main/java/se/simonsoft/cms/item/export/CmsExportJobBase.java
@@ -65,7 +65,11 @@ public abstract class CmsExportJobBase {
             sb.append(getJobPrefix());
             sb.append("/");
         }
-    	sb.append(getJobName());
+    	String name = getJobName();
+    	if (name.startsWith("/")) {
+    		name = name.replaceFirst("/", "");
+    	}
+    	sb.append(name);
         if (getJobExtension() != null) {
         	sb.append('.');
         	sb.append(getJobExtension());


### PR DESCRIPTION
We will never set a Job to prepared if a ExportItem returns false.
Fixed bug where a jobname prefixed with a slash generated a path where parts of the path could be empty strings.