### PR TITLE
Job name validation

### DIFF
--- a/src/main/java/se/simonsoft/cms/item/export/CmsExportJobBase.java
+++ b/src/main/java/se/simonsoft/cms/item/export/CmsExportJobBase.java
@@ -37,7 +37,7 @@ public abstract class CmsExportJobBase {
 		}
 		
 		if (jobName.isEmpty()) {
-			throw new IllegalArgumentException("job name can not be empty: " + jobName);
+			throw new IllegalArgumentException("Job name can not be empty: " + jobName);
 		}
 		
 		if (jobExtension.isEmpty()) {

--- a/src/main/java/se/simonsoft/cms/item/export/CmsExportJobBase.java
+++ b/src/main/java/se/simonsoft/cms/item/export/CmsExportJobBase.java
@@ -29,16 +29,17 @@ public abstract class CmsExportJobBase {
 	public CmsExportJobBase(CmsExportPrefix jobPrefix, String jobName, String jobExtension) {
 		
 		if (jobName == null) {
-			throw new IllegalArgumentException("Job name can not be null: " + jobName);
+			throw new IllegalArgumentException("Job name can not be null");
+		}
+		
+		if (jobName.isEmpty()) {
+			throw new IllegalArgumentException("Job name can not be empty: " + jobName);
 		}
 		
 		if (jobName.startsWith("/")) {
 			throw new IllegalArgumentException("Job name can not be prefixed with slash: " + jobName);
 		}
 		
-		if (jobName.isEmpty()) {
-			throw new IllegalArgumentException("Job name can not be empty: " + jobName);
-		}
 		
 		if (jobExtension.isEmpty()) {
 			throw new IllegalArgumentException("Export job extension must not be empty, null is allowed.");

--- a/src/main/java/se/simonsoft/cms/item/export/CmsExportJobBase.java
+++ b/src/main/java/se/simonsoft/cms/item/export/CmsExportJobBase.java
@@ -28,11 +28,17 @@ public abstract class CmsExportJobBase {
 
 	public CmsExportJobBase(CmsExportPrefix jobPrefix, String jobName, String jobExtension) {
 		
-		if (jobName == null || jobName.isEmpty()) {
-			throw new IllegalArgumentException("Not a valid export job name: " + jobName);
+		if (jobName == null) {
+			throw new IllegalArgumentException("Job name can not be null: " + jobName);
 		}
 		
-	    // TODO: Regex validating the export name. No slashes allowed etc.
+		if (jobName.startsWith("/")) {
+			throw new IllegalArgumentException("Job name can not be prefixed with slash: " + jobName);
+		}
+		
+		if (jobName.isEmpty()) {
+			throw new IllegalArgumentException("job name can not be empty: " + jobName);
+		}
 		
 		if (jobExtension.isEmpty()) {
 			throw new IllegalArgumentException("Export job extension must not be empty, null is allowed.");


### PR DESCRIPTION
 - Empty job name not allowed.
 - Job names prefixed with slash not allowed.