### PR TITLE
Fix revision compare logging

### DIFF
--- a/src/main/java/se/simonsoft/cms/item/RepoRevision.java
+++ b/src/main/java/se/simonsoft/cms/item/RepoRevision.java
@@ -177,10 +177,12 @@ public class RepoRevision implements Comparable<RepoRevision> {
 		RepoRevision r = (RepoRevision) obj;
 		if (number != r.getNumber()) return false;
 		if (date == null) {
-			logger.debug("Comparing revision {} that lacks timestamp with {}", getNumber(), r);
-			if (r.getDate() != null) return false;
+			if (r.getDate() != null) {
+				logger.warn("Comparing revision {} that lacks timestamp with {}", getNumber(), r);
+				return false;
+			}
 		} else if (r.getDate() == null) {
-			logger.debug("Comparing {} with revision that lacks timestamp {}", this, r.getNumber());
+			logger.warn("Comparing {} with revision that lacks timestamp {}", this, r.getNumber());
 			return false;
 		} else {
 			if (!date.equals(r.getDate())) {


### PR DESCRIPTION
Moving log statement to correct location, when the comparison result is impacted by one revision lacking timestamp. 

Reverting to WARN level since it should now only log when comparison has been impacted.