### PR TITLE
Export prefix uppercase

### DIFF
--- a/src/main/java/se/simonsoft/cms/item/export/CmsExportMetaKey.java
+++ b/src/main/java/se/simonsoft/cms/item/export/CmsExportMetaKey.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 public class CmsExportMetaKey {
 
 	private final String key;
-	private static final Pattern NICE = Pattern.compile("([\\-a-zA-Z0-9]+)");
+	private static final Pattern NICE = Pattern.compile("[A-Za-z0-9-]{1,100}");
 	
 	public CmsExportMetaKey(String key) {
 

--- a/src/main/java/se/simonsoft/cms/item/export/CmsExportPrefix.java
+++ b/src/main/java/se/simonsoft/cms/item/export/CmsExportPrefix.java
@@ -22,7 +22,7 @@ public class CmsExportPrefix {
 
 	private final String prefix;
 	
-	private static final Pattern NICE = Pattern.compile("[a-z0-9-]+");
+	private static final Pattern NICE = Pattern.compile("[A-Za-z0-9-]{1,50}");
 	
 	public CmsExportPrefix(String prefix) {
 		Matcher m = NICE.matcher(prefix);

--- a/src/test/java/se/simonsoft/cms/item/export/CmsExportPrefixTest.java
+++ b/src/test/java/se/simonsoft/cms/item/export/CmsExportPrefixTest.java
@@ -1,0 +1,38 @@
+package se.simonsoft.cms.item.export;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class CmsExportPrefixTest {
+
+	@Test
+	public void test() {
+		new CmsExportPrefix("cms4");
+		new CmsExportPrefix("cms4-suffix");
+		new CmsExportPrefix("CMS4"); // Adding support for uppercase.
+		new CmsExportPrefix("01234567890123456789012345678901234567890123456789"); // 50 chars
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testLongString() {
+		new CmsExportPrefix("01234567890123456789012345678901234567890123456789morethan50");
+	}
+
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void testEmpty() {
+		new CmsExportPrefix("");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testCharPercent() {
+		new CmsExportPrefix("cms%");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testCharUnderscore() {
+		// Currently don't allow underscore since it is generally avoided in URLs.
+		new CmsExportPrefix("cms_");
+	}
+}


### PR DESCRIPTION
Still disallow underscore. Generally ugly in URLs.