### PR TITLE
Allow comma, space and pipe as config list separators.

### DIFF
--- a/src/main/java/se/simonsoft/cms/item/impl/CmsConfigOptionBase.java
+++ b/src/main/java/se/simonsoft/cms/item/impl/CmsConfigOptionBase.java
@@ -70,12 +70,12 @@ public class CmsConfigOptionBase<T> implements CmsConfigOption {
 	
 	private static List<String> getList(String multiValue) {
 		
-		String[] split = multiValue.split("\\|");
+		String[] split = multiValue.split("[|\\s,]+");
 		List<String> list = new LinkedList<String>();
 		for (String s : split) {
 			String t = s.trim();
 			if (t.length() == 0) {
-				throw new IllegalArgumentException("Got empty value in multi-value configuration option: " + multiValue);
+				throw new IllegalArgumentException("Got an empty value in multi-value configuration option: " + multiValue);
 			}
 			list.add(t);
 		}

--- a/src/test/java/se/simonsoft/cms/item/impl/CmsConfigOptionBaseTest.java
+++ b/src/test/java/se/simonsoft/cms/item/impl/CmsConfigOptionBaseTest.java
@@ -1,0 +1,31 @@
+package se.simonsoft.cms.item.impl;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class CmsConfigOptionBaseTest {
+
+	@Test
+	public void test() {
+		CmsConfigOptionBase<String> o = new CmsConfigOptionBase<String>("cmsconfig:bogus", "banana|mango ");
+		assertEquals("cmsconfig", o.getNamespace());
+		assertEquals("bogus", o.getKey());
+		assertEquals("trim, always has done", "banana|mango", o.getValueString());
+		assertEquals("trim, always has done", Arrays.asList("banana", "mango"), o.getValueList());
+	}
+	
+	@Test
+	public void testSplit() {
+		// #1321 Adding support for comma and space.
+		CmsConfigOptionBase<String> o = new CmsConfigOptionBase<String>("cmsconfig:bogus", "pear,banana, mango|grape, ");
+		assertEquals("cmsconfig", o.getNamespace());
+		assertEquals("bogus", o.getKey());
+		assertEquals("trim, always has done", "pear,banana, mango|grape,", o.getValueString());
+		assertEquals("trim, always has done", Arrays.asList("pear", "banana", "mango", "grape"), o.getValueList());
+		assertEquals(4, o.getValueList().size());
+	}
+
+}


### PR DESCRIPTION
#1321

Intended to simplify config, avoid having to know which separator to use where.

Multi-value config that needs space or comma will have to be JSON.